### PR TITLE
Use the next() builtin for Python 3 compatibility

### DIFF
--- a/couchdb/http.py
+++ b/couchdb/http.py
@@ -315,7 +315,7 @@ class Session(object):
                     if ecode not in self.retryable_errors:
                         raise
                     try:
-                        delay = retries.next()
+                        delay = next(retries)
                     except StopIteration:
                         # No more retries, raise last socket error.
                         raise e

--- a/couchdb/tests/couchhttp.py
+++ b/couchdb/tests/couchhttp.py
@@ -25,6 +25,12 @@ class SessionTestCase(testutil.TempDatabaseMixin, unittest.TestCase):
         self.assertRaises(socket.timeout, body.read)
         self.assertTrue(time.time() - start < timeout * 1.3)
 
+    def test_timeout_retry(self):
+        dbname, db = self.temp_db()
+        timeout = 1e-12
+        session = http.Session(timeout=timeout, retryable_errors=["timed out"])
+        self.assertRaises(socket.timeout, session.request, 'GET', db.resource.url)
+
 
 class ResponseBodyTestCase(unittest.TestCase):
     def test_close(self):


### PR DESCRIPTION
`iterator.next()` has been replaced by `next(iterator)` in Python 3.
