### PR TITLE
fix skip processing in iterview

### DIFF
--- a/couchdb/client.py
+++ b/couchdb/client.py
@@ -881,7 +881,7 @@ class Database(object):
             if len(rows) <= batch or (limit is not None and limit == 0):
                 break
             # Update options with start keys for next loop.
-            options.update(startkey=rows[-1]['key'], startkey_docid=rows[-1]['id'])
+            options.update(startkey=rows[-1]['key'], startkey_docid=rows[-1]['id'], skip=0)
 
     def show(self, name, docid=None, **options):
         """Call a 'show' function.

--- a/couchdb/tests/client.py
+++ b/couchdb/tests/client.py
@@ -786,6 +786,11 @@ class ViewIterationTestCase(testutil.TempDatabaseMixin, unittest.TestCase):
         self.assertEqual(len(list(self.db.iterview('test/nums', self.num_docs))), self.num_docs)
         self.assertEqual(len(list(self.db.iterview('test/nums', self.num_docs + 1))), self.num_docs)
 
+    def test_batchsizes_with_skip(self):
+        self.assertEqual(
+            len(list(self.db.iterview('test/nums', self.num_docs / 10, skip=self.num_docs / 2))),
+            self.num_docs / 2)
+
     def test_limit(self):
         # limit=0 doesn't make sense for iterview.
         self.assertRaises(ValueError, lambda: next(self.db.iterview('test/nums', 10, limit=0)))


### PR DESCRIPTION
Do not miss too much ! Use 'skip' only in the first request
