### PR TITLE
Treat image attachments as binary blobs;tools/dump fetch attachments

### DIFF
--- a/couchdb/multipart.py
+++ b/couchdb/multipart.py
@@ -150,7 +150,9 @@ class MultipartWriter(object):
             else:
                 content = content.encode('utf-8')
                 mimetype = mimetype + ';charset=utf-8'
-        elif 'charset' not in params:
+        # exclude images from being treated as a string
+        # XXX: is there a better way to do this??
+        elif 'charset' not in params and 'image/' not in ctype:
             try:
                 content.decode('utf-8')
             finally:

--- a/couchdb/tools/dump.py
+++ b/couchdb/tools/dump.py
@@ -22,9 +22,10 @@ from couchdb.multipart import write_multipart
 
 BULK_SIZE = 1000
 
-def dump_docs(envelope, docs):
-    for doc in docs:
+def dump_docs(envelope, _ids, db):
+    for _id in _ids:
 
+        doc = db.get(_id, attachments=True)
         print >> sys.stderr, 'Dumping document %r' % doc.id
         attachments = doc.pop('_attachments', {})
         jsondoc = json.encode(doc)
@@ -61,8 +62,8 @@ def dump_db(dburl, username=None, password=None, boundary=None,
     envelope = write_multipart(output, boundary=boundary)
     start, num = 0, db.info()['doc_count']
     while start < num:
-        opts = {'limit': bulk_size, 'skip': start, 'include_docs': True}
-        dump_docs(envelope, [row.doc for row in db.view('_all_docs', **opts)])
+        opts = {'limit': bulk_size, 'skip': start}
+        dump_docs(envelope, [row.id for row in db.view('_all_docs', **opts)], db)
         start += bulk_size
 
     envelope.close()


### PR DESCRIPTION
The _all_docs view only returns attachment stubs and doesn't accept the attachments=true attribute so I changed the dump tool to fetch full documents in the main loop.  Also added guard check to mulitpart writer to not attempt to decode images and not bloat them with a utf-8 encoding.  There is probably a better way to detect binary mimetypes, if pointed in the right direction I can improve that check.
