### PR TITLE
UnicodeDecodeError when self._buffer table contains an unicode value

### DIFF
--- a/couchdb/http.py
+++ b/couchdb/http.py
@@ -561,15 +561,11 @@ def extract_credentials(url):
 
 
 def basic_auth(credentials):
-    """Generates authorization header value for given credentials.
-    >>> basic_auth(('root', 'relax'))
-    u'Basic cm9vdDpyZWxheA=='
-    >>> basic_auth(None)
-    >>> basic_auth(())
-    """
+    """Generates authorization header value for given credentials."""
     if credentials:
         token = b64encode(('%s:%s' % credentials).encode('latin1'))
-        return 'Basic %s' % (token.strip().decode('latin1'))
+        header = 'Basic %s' % token.strip().decode('ascii')
+        return header.encode('ascii')
 
 
 def quote(string, safe=''):

--- a/couchdb/tests/client.py
+++ b/couchdb/tests/client.py
@@ -130,6 +130,12 @@ class ServerTestCase(testutil.TempDatabaseMixin, unittest.TestCase):
         finally:
             server.delete(dbname)
 
+    def test_basic_auth(self):
+        url = "http://root:password@localhost:5984/"
+        server = client.Server(url)
+        dbname = 'couchdb-python/test_basic_auth'
+        self.assertRaises(http.Unauthorized, server.create, dbname)
+
 
 class DatabaseTestCase(testutil.TempDatabaseMixin, unittest.TestCase):
 

--- a/couchdb/tests/couchhttp.py
+++ b/couchdb/tests/couchhttp.py
@@ -93,12 +93,20 @@ class CacheTestCase(testutil.TempDatabaseMixin, unittest.TestCase):
         self.assertTrue('baz' in cache.by_url)
 
 
+class BasicAuthTestCase(testutil.TempDatabaseMixin, unittest.TestCase):
+
+    def test_basic_auth_builder(self):
+        header = http.basic_auth(('root', 'relax'))
+        self.assertTrue(isinstance(header, util.btype))
+
+
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(testutil.doctest_suite(http))
     suite.addTest(unittest.makeSuite(SessionTestCase, 'test'))
     suite.addTest(unittest.makeSuite(ResponseBodyTestCase, 'test'))
     suite.addTest(unittest.makeSuite(CacheTestCase, 'test'))
+    suite.addTest(unittest.makeSuite(BasicAuthTestCase, 'test'))
     return suite
 
 

--- a/couchdb/util2.py
+++ b/couchdb/util2.py
@@ -1,10 +1,11 @@
 
 __all__ = [
     'StringIO', 'urlsplit', 'urlunsplit', 'urlquote', 'urlunquote',
-    'urlencode', 'utype', 'ltype', 'strbase', 'funcode', 'urlparse',
+    'urlencode', 'utype', 'btype', 'ltype', 'strbase', 'funcode', 'urlparse',
 ]
 
 utype = unicode
+btype = str
 ltype = long
 strbase = str, bytes, unicode
 

--- a/couchdb/util3.py
+++ b/couchdb/util3.py
@@ -1,10 +1,11 @@
 
 __all__ = [
     'StringIO', 'urlsplit', 'urlunsplit', 'urlquote', 'urlunquote',
-    'urlencode', 'utype', 'ltype', 'strbase', 'funcode', 'urlparse',
+    'urlencode', 'utype', 'btype', 'ltype', 'strbase', 'funcode', 'urlparse',
 ]
 
 utype = str
+btype = bytes
 ltype = int
 strbase = str, bytes
 


### PR DESCRIPTION
If msg is an unicode string here: https://github.com/djc/couchdb-python/blob/master/couchdb/http.py#L66
Then the CouchDB backend fails with UnicodeDecodeError here: https://github.com/djc/couchdb-python/blob/master/couchdb/http.py#L69
