### PR TITLE
Add a flag to allow use of unverified SSL certs on Python 2.7.9+

### DIFF
--- a/couchdb/client.py
+++ b/couchdb/client.py
@@ -271,6 +271,13 @@ class Database(object):
     2
 
     >>> del server['python-tests']
+
+    If you need to connect to a database with an unverified or self-signed SSL
+    certificate, you can re-initialize your ConnectionPool as follows (only
+    applicable for Python 2.7.9+):
+
+    >>> db = Database(url)
+    >>> db.resource.session.disable_ssl_verification()
     """
 
     def __init__(self, url, name=None, session=None):

--- a/couchdb/client.py
+++ b/couchdb/client.py
@@ -276,7 +276,6 @@ class Database(object):
     certificate, you can re-initialize your ConnectionPool as follows (only
     applicable for Python 2.7.9+):
 
-    >>> db = Database(url)
     >>> db.resource.session.disable_ssl_verification()
     """
 

--- a/couchdb/client.py
+++ b/couchdb/client.py
@@ -67,18 +67,20 @@ class Server(object):
     >>> del server['python-tests']
     """
 
-    def __init__(self, url=DEFAULT_BASE_URL, full_commit=True, session=None):
+    def __init__(self, url=DEFAULT_BASE_URL, full_commit=True, session=None, disable_ssl_verification=False):
         """Initialize the server object.
 
         :param url: the URI of the server (for example
                     ``http://localhost:5984/``)
         :param full_commit: turn on the X-Couch-Full-Commit header
         :param session: an http.Session instance or None for a default session
+        :param disable_ssl_verification: disable ssl verification on Python 2.7.9+
         """
         if isinstance(url, util.strbase):
-            self.resource = http.Resource(url, session or http.Session())
+            session = session or http.Session(disable_ssl_verification=disable_ssl_verification)
+            self.resource = http.Resource(url, session)
         else:
-            self.resource = url # treat as a Resource object
+            self.resource = url  # treat as a Resource object
         if not full_commit:
             self.resource.headers['X-Couch-Full-Commit'] = 'false'
 

--- a/couchdb/client.py
+++ b/couchdb/client.py
@@ -67,20 +67,18 @@ class Server(object):
     >>> del server['python-tests']
     """
 
-    def __init__(self, url=DEFAULT_BASE_URL, full_commit=True, session=None, disable_ssl_verification=False):
+    def __init__(self, url=DEFAULT_BASE_URL, full_commit=True, session=None):
         """Initialize the server object.
 
         :param url: the URI of the server (for example
                     ``http://localhost:5984/``)
         :param full_commit: turn on the X-Couch-Full-Commit header
         :param session: an http.Session instance or None for a default session
-        :param disable_ssl_verification: disable ssl verification on Python 2.7.9+
         """
         if isinstance(url, util.strbase):
-            session = session or http.Session(disable_ssl_verification=disable_ssl_verification)
-            self.resource = http.Resource(url, session)
+            self.resource = http.Resource(url, session or http.Session())
         else:
-            self.resource = url  # treat as a Resource object
+            self.resource = url # treat as a Resource object
         if not full_commit:
             self.resource.headers['X-Couch-Full-Commit'] = 'false'
 

--- a/couchdb/http.py
+++ b/couchdb/http.py
@@ -428,9 +428,10 @@ class InsecureHTTPSConnection(HTTPSConnection):
 
     See: https://docs.python.org/2/library/httplib.html#httplib.HTTPSConnection
     """
-    def __init__(self, *a, **k):
-        k['context'] = ssl._create_unverified_context()
-        HTTPSConnection.__init__(self, *a, **k)
+    if sys.version_info >= (2,7,9):
+        def __init__(self, *a, **k):
+            k['context'] = ssl._create_unverified_context()
+            HTTPSConnection.__init__(self, *a, **k)
 
 
 class ConnectionPool(object):

--- a/couchdb/http.py
+++ b/couchdb/http.py
@@ -54,7 +54,7 @@ if sys.version < '2.7':
 
         Based on code originally copied from Python 2.7's httplib module.
         """
-        
+
         def endheaders(self, message_body=None):
             if self.__dict__['_HTTPConnection__state'] == _CS_REQ_STARTED:
                 self.__dict__['_HTTPConnection__state'] = _CS_REQ_SENT
@@ -219,11 +219,20 @@ class Session(object):
         self.perm_redirects = {}
         self._disable_ssl_verification = False
         self._timeout = timeout
-        self.connection_pool = ConnectionPool(self._timeout, disable_ssl_verification=self._disable_ssl_verification)
+        self.connection_pool = ConnectionPool(
+            self._timeout,
+            disable_ssl_verification=self._disable_ssl_verification)
         self.retry_delays = list(retry_delays) # We don't want this changing on us.
         self.retryable_errors = set(retryable_errors)
 
     def disable_ssl_verification(self):
+        """
+        Disable verification of SSL certificates and re-initialize the ConnectionPool.
+        Only applicable on Python 2.7.9+ as previous versions of Python don't verify
+        SSL certs.
+
+        :return:
+        """
         self._disable_ssl_verification = True
         self.connection_pool = ConnectionPool(self._timeout, disable_ssl_verification=self._disable_ssl_verification)
 


### PR DESCRIPTION
In Python 2.7. the behavior of `httplib` was changed to verify SSL certs by default (see [this](https://docs.python.org/2/library/httplib.html#httplib.HTTPSConnection)), making couchdb-python unusable with CouchDB servers using self-signed SSL certificates. 

These commits add an extra parameter to the `Server()` class optionally disabling SSL verification to re-allow the previous behavior. 