### PR TITLE
Update example python view code to avoid KeyErrors

### DIFF
--- a/doc/views.rst
+++ b/doc/views.rst
@@ -13,7 +13,7 @@ After restarting CouchDB, the Futon view editor should show ``python`` in
 the language pull-down menu. Here's some sample view code to get you started::
 
     def fun(doc):
-        if doc.get('date'):
+        if 'date' in doc:
             yield doc['date'], doc
 
 Note that the ``map`` function uses the Python ``yield`` keyword to emit

--- a/doc/views.rst
+++ b/doc/views.rst
@@ -13,7 +13,7 @@ After restarting CouchDB, the Futon view editor should show ``python`` in
 the language pull-down menu. Here's some sample view code to get you started::
 
     def fun(doc):
-        if doc['date']:
+        if doc.get('date'):
             yield doc['date'], doc
 
 Note that the ``map`` function uses the Python ``yield`` keyword to emit


### PR DESCRIPTION
If the reader doesn't happen to have the 'date' key in one of the documents the old code would cause couchdb to throw. If the reader happened to be using futon, it would produce a useless 'no response' error.

By using .get() you'll always at least get None and this code can be used against any database.