### PR TITLE
Basic update handler support.

### DIFF
--- a/couchdb/tests/view.py
+++ b/couchdb/tests/view.py
@@ -102,38 +102,46 @@ class ViewServerTestCase(unittest.TestCase):
         self.assertEqual(output.getvalue(),
                          b'[true, [0]]\n')
 
-    def test_update(self):
-        import json
-        commands = [
-            [
-                'ddoc',
-                'new',
-                '_design/test_update',
-                {
-                    '_id': '_design/test_update',
-                    '_rev': '8-d7379de23a751dc2a19e5638a7bbc5cc',
-                    'language': 'python',
-                    'updates': {
-                        'inc': '''\
+    def command_ddoc_add(self):
+        return [
+            'ddoc',
+            'new',
+            '_design/test_update',
+            {
+                '_id': '_design/test_update',
+                '_rev': '8-d7379de23a751dc2a19e5638a7bbc5cc',
+                'language': 'python',
+                'updates': {
+                    'inc': '''\
 def fun(obj, req):
     if obj is not None:
         obj['field'] += 1
     return [obj, {"body": "."}]
 ''',
-                    }
-                },
+                }
+            },
+        ]
+
+    def test_update(self):
+        import json
+        request = {
+            'method': 'POST',
+            'query': {},
+            'body': '',
+        }
+        commands = [
+            self.command_ddoc_add(),
+            [
+                'ddoc',
+                '_design/test_update',
+                ['updates', 'inc'],
+                [None, request]
             ],
             [
                 'ddoc',
                 '_design/test_update',
                 ['updates', 'inc'],
-                [None, {}]
-            ],
-            [
-                'ddoc',
-                '_design/test_update',
-                ['updates', 'inc'],
-                [{'field': 41, 'other_field': 'x'}, {}]
+                [{'field': 41, 'other_field': 'x'}, request]
             ],
         ]
         input = StringIO(b'\n'.join(json.dumps(c).encode('utf-8')
@@ -150,6 +158,33 @@ def fun(obj, req):
         self.assertEqual(
             results[2],
             ['up', {'field': 42, 'other_field': 'x'}, {'body': '.'}])
+
+    def test_update_wrong_method(self):
+        import json
+        request = {
+            'method': 'GET',
+            'query': {},
+            'body': '',
+        }
+        commands = [
+            self.command_ddoc_add(),
+            [
+                'ddoc',
+                '_design/test_update',
+                ['updates', 'inc'],
+                [None, request]
+            ],
+        ]
+        input = StringIO(b'\n'.join(json.dumps(c).encode('utf-8')
+                                    for c in commands))
+        output = StringIO()
+        view.run(input=input, output=output)
+        results = [
+            json.loads(l.decode('utf-8'))
+            for l in output.getvalue().strip().split(b'\n')
+        ]
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[1][2]['status'], 405)
 
 
 def suite():

--- a/couchdb/tests/view.py
+++ b/couchdb/tests/view.py
@@ -114,14 +114,12 @@ class ViewServerTestCase(unittest.TestCase):
                     '_rev': '8-d7379de23a751dc2a19e5638a7bbc5cc',
                     'language': 'python',
                     'updates': {
-                        'inc': {
-                            'map': '''\
+                        'inc': '''\
 def fun(obj, req):
     if obj is not None:
         obj['field'] += 1
     return [obj, {"body": "."}]
 ''',
-                        }
                     }
                 },
             ],

--- a/couchdb/view.py
+++ b/couchdb/view.py
@@ -148,7 +148,7 @@ def run(input=sys.stdin, output=sys.stdout):
             ddoc = ddocs[cmd[0]]
             action = cmd[1]
             if action[0] == 'updates':
-                if cmd[2][1]['method'] != 'POST':
+                if cmd[2][1]['method'] not in ('POST', 'PUT'):
                     return [
                         'up',
                         None,

--- a/couchdb/view.py
+++ b/couchdb/view.py
@@ -53,7 +53,7 @@ def run(input=sys.stdin, output=sys.stdout):
         del functions[:]
         return True
 
-    def add_fun(string):
+    def compile_fun(string):
         string = BOM_UTF8 + string.encode('utf-8')
         globals_ = {}
         try:
@@ -73,7 +73,10 @@ def run(input=sys.stdin, output=sys.stdout):
         function = list(globals_.values())[0]
         if type(function) is not FunctionType:
             return err
-        functions.append(function)
+        return function
+
+    def add_fun(string):
+        functions.append(compile_fun(string))
         return True
 
     def map_doc(doc):

--- a/couchdb/view.py
+++ b/couchdb/view.py
@@ -140,7 +140,7 @@ def run(input=sys.stdin, output=sys.stdout):
         if cmd[0] == 'new':
             ddoc = cmd[2]
             ddoc['updates'] = dict(
-                (name, {'map': compile_fun(value['map'])})
+                (name, compile_fun(value))
                 for name, value in ddoc['updates'].items())
             ddocs[cmd[1]] = ddoc
             return True
@@ -148,7 +148,7 @@ def run(input=sys.stdin, output=sys.stdout):
             ddoc = ddocs[cmd[0]]
             action = cmd[1]
             if action[0] == 'updates':
-                fun = ddoc['updates'][action[1]]['map']
+                fun = ddoc['updates'][action[1]]
                 doc, body = fun(*cmd[2])
                 res = ['up', doc, body]
                 sys.stderr.flush()

--- a/couchdb/view.py
+++ b/couchdb/view.py
@@ -34,10 +34,14 @@ def run(input=sys.stdin, output=sys.stdout):
 
     def _writejson(obj):
         obj = json.encode(obj)
-        if isinstance(obj, util.utype):
-            obj = obj.encode('utf-8')
-        output.write(obj)
-        output.write(b'\n')
+        if hasattr(output, 'encoding'):
+            output.write(obj)
+            output.write('\n')
+        else:
+            if isinstance(obj, util.utype):
+                obj = obj.encode('utf-8')
+            output.write(obj)
+            output.write(b'\n')
         output.flush()
 
     def _log(message):

--- a/couchdb/view.py
+++ b/couchdb/view.py
@@ -148,10 +148,17 @@ def run(input=sys.stdin, output=sys.stdout):
             ddoc = ddocs[cmd[0]]
             action = cmd[1]
             if action[0] == 'updates':
-                fun = ddoc['updates'][action[1]]
-                doc, body = fun(*cmd[2])
-                res = ['up', doc, body]
-                sys.stderr.flush()
+                if cmd[2][1]['method'] != 'POST':
+                    return [
+                        'up',
+                        None,
+                        {'status': 405, 'body': 'Method not allowed'},
+                    ]
+                else:
+                    fun = ddoc['updates'][action[1]]
+                    doc, body = fun(*cmd[2])
+                    res = ['up', doc, body]
+                    sys.stderr.flush()
                 return res
 
 

--- a/doc/views.rst
+++ b/doc/views.rst
@@ -1,10 +1,11 @@
 Writing views in Python
 =======================
 
-The couchdb-python package comes with a view server to allow you to write
-views in Python instead of JavaScript. When couchdb-python is installed, it
-will install a script called couchpy that runs the view server. To enable
-this for your CouchDB server, add the following section to local.ini::
+The couchdb-python package comes with a query server to allow you to
+write views or update handlers in Python instead of JavaScript. When
+couchdb-python is installed, it will install a script called couchpy
+that runs the view server. To enable this for your CouchDB server, add
+the following section to local.ini::
 
     [query_servers]
     python=/usr/bin/couchpy
@@ -18,3 +19,15 @@ the language pull-down menu. Here's some sample view code to get you started::
 
 Note that the ``map`` function uses the Python ``yield`` keyword to emit
 values, where JavaScript views use an ``emit()`` function.
+
+Here's an example update handler code that will increment the
+``field`` member of an existing document. The name of the ``field`` to
+increment is passed in the query string::
+
+    def fun(obj, req):
+        field = req.query['field']
+        if obj is not None and field in obj:
+            obj[field] += 1
+            return [obj, {"body": "incremented"}]
+        else:
+            return [None, {"body": "no such document or field"}]


### PR DESCRIPTION
Same player play again, passing Travis build, with a unit test and some doc.

Implementation for some of the `ddoc` query server call, enabling to write update handlers in python. I'm very new to CouchDB so this might be incomplete, but it works for me so far. I might keep adding support as my needs evolve.