### PR TITLE
Fix id and rev for some special documents

### DIFF
--- a/couchdb/client.py
+++ b/couchdb/client.py
@@ -1011,7 +1011,8 @@ class Document(dict):
 
         :rtype: basestring
         """
-        return self['_id']
+        return self.get('_id')
+
 
     @property
     def rev(self):
@@ -1019,7 +1020,7 @@ class Document(dict):
 
         :rtype: basestring
         """
-        return self['_rev']
+        return self.get('_rev')
 
 
 class View(object):


### PR DESCRIPTION
Some special documents (e.g. \_security) have no id or rev, this results
in an error when trying to get them. This is done in the `__repr__` method so
these documents can not be printed.

This pull request makes them return `None` in those cases.