### PR TITLE
Make Client.update_doc documentation clearer

### DIFF
--- a/couchdb/client.py
+++ b/couchdb/client.py
@@ -1006,7 +1006,10 @@ class Database(object):
         :param name: the name of the update handler function in the format
                      ``designdoc/updatename``.
         :param docid: optional ID of a document to pass to the update handler.
-        :param options: optional query string parameters.
+        :param options: additional (optional) params to pass to the underlying
+                        http resource handler, including ``headers``, ``body``,
+                        and ```path```. Other arguments will be treated as
+                        query string params. See :class:`couchdb.http.Resource`
         :return: (headers, body) tuple, where headers is a dict of headers
                  returned from the list function and body is a readable
                  file-like instance


### PR DESCRIPTION
I was a little thrown off by the documentation here, as there didn't
seem to be a way to provide my own request body to the request when
calling an update handler; the documentation only indicates that query
string params can be given as extra arguments.

A little digging into the code shows that options are just passed to the
post/put methods intact, so params of those methods can indeed be
provided, including path (probably not recommended!), body, and headers.
I've updated the documentation accordingly.