### PR TITLE
add error handling to couchdb.loader

### DIFF
--- a/couchdb/loader.py
+++ b/couchdb/loader.py
@@ -109,10 +109,12 @@ def load_design_doc(directory, strip=False, predicate=lambda x: True):
         for name in dirnames:
             if name == '_attachments':
                 raise NotImplementedError("_attachments are not supported")
-            subkey, subthing = objects[os.path.join(dirpath, name)]
+            fullpath = os.path.join(dirpath, name)
+            if not predicate(fullpath): continue
+            subkey, subthing = objects[fullpath]
             if subkey in ob:
-                raise DuplicateKeyError("directory '{0}{1}' clobbers key '{2}'"
-                                        .format(dirpath, name, subkey))
+                raise DuplicateKeyError("directory '{0}' clobbers key '{1}'"
+                                        .format(fullpath,subkey))
             ob[subkey] = subthing
 
     return ob

--- a/couchdb/loader.py
+++ b/couchdb/loader.py
@@ -84,7 +84,7 @@ def load_design_doc(directory, strip=False, predicate=lambda x: True):
     objects = {}
 
     if not os.path.isdir(directory):
-        raise OSError("No directory: '{}'".format(directory))
+        raise OSError("No directory: '{0}'".format(directory))
 
     for (dirpath, dirnames, filenames) in os.walk(directory, topdown=False):
         key = os.path.split(dirpath)[-1]
@@ -96,7 +96,7 @@ def load_design_doc(directory, strip=False, predicate=lambda x: True):
             fullname = os.path.join(dirpath, name)
             if not predicate(fullname): continue
             if fkey in ob:
-                raise DuplicateKeyError("file '{}' clobbers key '{}'"
+                raise DuplicateKeyError("file '{0}' clobbers key '{1}'"
                                         .format(fullname, fkey))
             with codecs.open(fullname, 'r', 'utf-8') as f:
                 contents = f.read()
@@ -111,7 +111,7 @@ def load_design_doc(directory, strip=False, predicate=lambda x: True):
                 raise NotImplementedError("_attachments are not supported")
             subkey, subthing = objects[os.path.join(dirpath, name)]
             if subkey in ob:
-                raise DuplicateKeyError("directory '{}{}' clobbers key '{}'"
+                raise DuplicateKeyError("directory '{0}{1}' clobbers key '{2}'"
                                         .format(dirpath, name, subkey))
             ob[subkey] = subthing
 
@@ -123,7 +123,7 @@ def main():
     try:
         directory = sys.argv[1]
     except IndexError:
-        sys.stderr.write("Usage:\n\t{} [directory]\n".format(sys.argv[0]))
+        sys.stderr.write("Usage:\n\t{0} [directory]\n".format(sys.argv[0]))
         sys.exit(1)
     obj = load_design_doc(directory)
     sys.stdout.write(json.dumps(obj, indent=2))

--- a/couchdb/tests/__main__.py
+++ b/couchdb/tests/__main__.py
@@ -9,7 +9,8 @@
 import unittest
 
 from couchdb.tests import client, couch_tests, design, couchhttp, \
-                          multipart, mapping, view, package, tools
+                          multipart, mapping, view, package, tools, \
+                          loader
 
 
 def suite():
@@ -23,6 +24,7 @@ def suite():
     suite.addTest(couch_tests.suite())
     suite.addTest(package.suite())
     suite.addTest(tools.suite())
+    suite.addTest(loader.suite())
     return suite
 
 

--- a/couchdb/tests/_loader/filters.xml
+++ b/couchdb/tests/_loader/filters.xml
@@ -1,0 +1,1 @@
+<p>Assert clobber of 'filters' directory</p>

--- a/couchdb/tests/_loader/language.xml
+++ b/couchdb/tests/_loader/language.xml
@@ -1,0 +1,1 @@
+<p>Assert clobber of 'language' (without an extension)</p>

--- a/couchdb/tests/loader.py
+++ b/couchdb/tests/loader.py
@@ -20,10 +20,38 @@ expected = {
 
 class LoaderTestCase(unittest.TestCase):
 
+    directory = os.path.join(os.path.dirname(__file__), '_loader')
+
     def test_loader(self):
-        directory = os.path.join(os.path.dirname(__file__), '_loader')
-        doc = loader.load_design_doc(directory, strip_files=True)
+        doc = loader.load_design_doc(self.directory,
+                                     strip=True,
+                                     predicate=lambda x: \
+                                        not x.endswith('.xml'))
         self.assertEqual(doc, expected)
+
+    def test_clobber_1(self):
+        def clobber():
+            doc = loader.load_design_doc(self.directory,
+                                     strip=True,
+                                     predicate=lambda x: \
+                                     not x.endswith('filters.xml'))
+
+        self.assertRaises(loader.DuplicateKeyError, clobber)
+
+    def test_clobber_2(self):
+        def clobber():
+            doc = loader.load_design_doc(self.directory,
+                                     strip=True,
+                                     predicate=lambda x: \
+                                     not x.endswith('language.xml'))
+
+        self.assertRaises(loader.DuplicateKeyError, clobber)
+
+    def test_bad_directory(self):
+        def bad_directory():
+            doc = loader.load_design_doc('directory_does_not_exist')
+
+        self.assertRaises(OSError, bad_directory)
 
 
 def suite():


### PR DESCRIPTION
If two files or directories map to the same key, an error is raised. This is important because editors tend to leave filename.js~ files that could cause surprises.

If the target directory does not exist, an error is raised.

strip_files parameter shortened to just strip.