### PR TITLE
Fix HTTP auth password encoding

### DIFF
--- a/couchdb/http.py
+++ b/couchdb/http.py
@@ -362,7 +362,7 @@ class Session(object):
             if num_redirects > self.max_redirects:
                 raise RedirectLimit('Redirection limit exceeded')
             location = resp.getheader('location')
-            
+
             # in case of relative location: add scheme and host to the location
             location_split = util.urlsplit(location)
 
@@ -592,7 +592,7 @@ class Resource(object):
 def extract_credentials(url):
     """Extract authentication (user name and password) credentials from the
     given URL.
-    
+
     >>> extract_credentials('http://localhost:5984/_config/')
     ('http://localhost:5984/_config/', None)
     >>> extract_credentials('http://joe:secret@localhost:5984/_config/')
@@ -620,8 +620,8 @@ def basic_auth(credentials):
     >>> basic_auth(())
     """
     if credentials:
-        token = b64encode(('%s:%s' % credentials).encode('latin1'))
-        return ('Basic %s' % token.strip().decode('latin1')).encode('ascii')
+        token = b64encode(('%s:%s' % credentials).encode('utf-8'))
+        return ('Basic %s' % token.strip().decode('utf-8')).encode('ascii')
 
 
 def quote(string, safe=''):


### PR DESCRIPTION
Username/password encoding in HTTP basic auth is currently broken for non-ASCII password.

Example with user `user` and password `unusual-char-é`. With curl it works as expected:

```shell
curl -v http://user:unusual-char-%C3%A9@localhost:5984/
```

```
> GET / HTTP/1.1
> Authorization: Basic YWxpY2U6YWRyaWVuPTohw6k=
>
< HTTP/1.1 200 OK
```

But with couchdb-python the string is decoded from `utf-8` then re-encoded into `latin1`, causing an incorrect Authorization header:

```python
url = 'http://user:unusual-char-%C3%A9@localhost:5984/'
couchdb.Server(url).version()
```

```
> GET / HTTP/1.1
> Authorization: Basic dXNlcjp1bnVzdWFsLWNoYXIt6Q==
>
< HTTP/1.1 401 Unauthorized
```

This patch fixes this wrong encoding charset by using `utf-8` (used by default by CouchDB) instead of `latin1`.

Closes: #301