### PR TITLE
Fix "Database does not exist." on couchdb.version()

### DIFF
--- a/couchdb/client.py
+++ b/couchdb/client.py
@@ -111,7 +111,7 @@ class Server(object):
     def __nonzero__(self):
         """Return whether the server is available."""
         try:
-            self.resource.head()
+            self.resource.head('/')
             return True
         except:
             return False
@@ -162,7 +162,7 @@ class Server(object):
         to check for the availability of the server.
 
         :rtype: `unicode`"""
-        status, headers, data = self.resource.get_json()
+        status, headers, data = self.resource.get_json('/')
         return data['version']
 
     def stats(self, name=None):


### PR DESCRIPTION
At least from version 2.0, it is required to query `host:5984/` (not just `host:5984`) to get the version information:

    {"couchdb":"Welcome","version":"2.0.0-RC4","vendor":{"name":"The Apache Software Foundation"}}

If the trailing slash is omitted, it results in an error:

    {"error":"not_found","reason":"Database does not exist."}

This patch fixes methods on class `Server` that omit the trailing slash.

Closes: #303