### PR TITLE
Add missing http.Forbidden error

### DIFF
--- a/couchdb/__init__.py
+++ b/couchdb/__init__.py
@@ -8,7 +8,8 @@
 
 from .client import Database, Document, Server
 from .http import HTTPError, PreconditionFailed, Resource, \
-        ResourceConflict, ResourceNotFound, ServerError, Session, Unauthorized
+        ResourceConflict, ResourceNotFound, ServerError, Session, \
+        Unauthorized, Forbidden
 
 try:
     __version__ = __import__('pkg_resources').get_distribution('CouchDB').version

--- a/couchdb/http.py
+++ b/couchdb/http.py
@@ -38,8 +38,8 @@ from couchdb import json
 from couchdb import util
 
 __all__ = ['HTTPError', 'PreconditionFailed', 'ResourceNotFound',
-           'ResourceConflict', 'ServerError', 'Unauthorized', 'RedirectLimit',
-           'Session', 'Resource']
+           'ResourceConflict', 'ServerError', 'Unauthorized', 'Forbidden',
+           'RedirectLimit', 'Session', 'Resource']
 __docformat__ = 'restructuredtext en'
 
 
@@ -111,6 +111,12 @@ class ServerError(HTTPError):
 class Unauthorized(HTTPError):
     """Exception raised when the server requires authentication credentials
     but either none are provided, or they are incorrect.
+    """
+
+
+class Forbidden(HTTPError):
+    """Exception raised when the request requires an authorisation that the
+    current user does not have.
     """
 
 
@@ -411,6 +417,8 @@ class Session(object):
                 error = ''
             if status == 401:
                 raise Unauthorized(error)
+            elif status == 403:
+                raise Forbidden(error)
             elif status == 404:
                 raise ResourceNotFound(error)
             elif status == 409:

--- a/couchdb/tests/package.py
+++ b/couchdb/tests/package.py
@@ -11,7 +11,7 @@ class PackageTestCase(unittest.TestCase):
             'Server', 'Database', 'Document',
             # couchdb.http
             'HTTPError', 'PreconditionFailed', 'ResourceNotFound',
-            'ResourceConflict', 'ServerError', 'Unauthorized',
+            'ResourceConflict', 'ServerError', 'Unauthorized', 'Forbidden',
             'Resource', 'Session'
         ])
         exported = set(e for e in dir(couchdb) if not e.startswith('_'))


### PR DESCRIPTION
"401 Unauthorized" and "403 Forbidden" are two different HTTP errors. CouchDB uses the first one when the server requires authentication credentials, and the second one when the request requires an authorisation that the current user does not have.

For instance, using a `validate_doc_update` design document can result in "403 Forbidden" being returned. See the [official documentation](http://docs.couchdb.org/en/stable/couchapp/ddocs.html#validate-document-update-functions) for more details and examples:

    // user is not authorized to make the change but may re-authenticate
    throw({ unauthorized: 'Error message here.' });
    // change is not allowed
    throw({ forbidden: 'Error message here.' });

This patch adds Forbidden to the list of HTTP errors raised by couchdb-python.