### PR TITLE
method for mango query

### DIFF
--- a/couchdb/query_utils.py
+++ b/couchdb/query_utils.py
@@ -1,0 +1,64 @@
+try:
+    from functools import reduce
+except ImportError:
+    pass
+
+'''
+maybe overwrite
+'''
+
+class Q:
+    """
+        Q-object need for creating mango_query in filter function
+    """
+    OR = '$or'
+    AND = '$and'
+
+    def __init__(self, **kwarg):
+        """
+        :param kwarg: field__subfield1__...__mango_operator = value
+                      separate by double underscore - '__'
+        """
+        self.field_cond = list(kwarg.keys())[0]
+        self.val = list(kwarg.values())[0]
+
+    @property
+    def P(self):
+        """
+        P - parser
+        :return: dict for query
+        """
+        field_cond_list = self.field_cond.split('__')
+        field = field_cond_list[:-1]
+        cond = '$' + field_cond_list[-1]
+        parsed_field_cond = reduce(lambda x, y: {y: x},
+                                   reversed(field + [cond, self.val]))
+        return parsed_field_cond
+
+    def _combine(self, other, cond):
+        """
+        :param other: Q or _FQ objects
+        :param cond: or, and
+        :return:  _FQ object
+        """
+        query = dict()
+        query[cond] = [self.P, other.P]
+        return _FQ(query)
+
+    def __or__(self, other):
+        return self._combine(other, self.OR)
+
+    def __and__(self, other):
+        return self._combine(other, self.AND)
+
+
+class _FQ(Q):
+    '''
+        subobject need for _combine method in Q
+    '''
+    def __init__(self, val):
+        self.val = val
+
+    @property
+    def P(self):
+        return self.val


### PR DESCRIPTION
I suggest implementation for mango query (CouchDB 2) http://docs.couchdb.org/en/2.1.0/api/database/find.html.

I used django's filter implementation.
`data = db.filter(field__subfield1__...__mango_operator = value)`

Work:
1. Combination operators: http://docs.couchdb.org/en/2.1.0/api/database/find.html#combination-operators, except: $elemMatch, $allMatch.
2.  Condition operators http://docs.couchdb.org/en/2.1.0/api/database/find.html#condition-operators,
not tested types: Object, Array-$size, Miscellaneous - $mod.
3. Sort, limit, fields and other request json object but need test http://docs.couchdb.org/en/2.1.0/api/database/find.html#db-find

I will work on update. In first I would add Array operators - $elemMatch, $allMatch.